### PR TITLE
Make independant CI jobs run in parallel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: CI
 on:
   push:
     branches:
@@ -9,64 +9,53 @@ on:
     branches:
       - '**'
 jobs:
-
-  test:
-    name: Test
+  tests:
+    name: Unit and integrations tests
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        go: [1.13, 1.14]
     steps:
-    - name: Set up Go 1.14
-      uses: actions/setup-go@v1
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
       with:
-        go-version: 1.14
-      id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-
-    - name: Get dependencies
+        go-version: ${{ matrix.go }}
+    - name: Run tests
       run: |
         echo "::set-env name=GOPATH::$(go env GOPATH)"
         echo "::add-path::$(go env GOPATH)/bin"
-        go get golang.org/x/lint/golint
-        go get github.com/fzipp/gocyclo
-        go get github.com/gordonklaus/ineffassign
-        go get github.com/client9/misspell/cmd/misspell
-        go get github.com/rakyll/gotest
-
-    - name: Start MySQL
-      run: |
         sudo /etc/init.d/mysql start
         while ! mysqladmin ping --silent; do
           sleep 1
         done
-
-    - name: Setup MySQL database
-      run: |
         sudo mysql -proot -e 'CREATE DATABASE goyave CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
         sudo mysql -proot -e 'CREATE USER "goyave"@"%" IDENTIFIED BY "secret"'
         sudo mysql -proot -e 'GRANT ALL PRIVILEGES ON goyave.* TO "goyave"@"%"'
-
-    - name: Test
-      run: |
-        gotest -race -count=20 .
-        gotest -v -p 1 -race -coverprofile=coverage.txt -covermode=atomic -coverpkg=./... ./...
-        go vet $(go list ./...)
-        golint -set_exit_status $(go list ./...)
-        gocyclo -over 15 .
-        ineffassign .
-        misspell -error .
-
-    - name: Send coverage
+        go test -v -p 1 -race -coverprofile=coverage.txt -covermode=atomic -coverpkg=./... ./...
+    - if: ${{ matrix.go == 1.14 }}
       uses: shogo82148/actions-goveralls@v1
       with:
         path-to-profile: coverage.txt
-        parallel: true
-        
-  finish:
-    needs: test
+
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: shogo82148/actions-goveralls@v1
-        with:
-          parallel-finished: true
+    - uses: actions/checkout@v2
+    - name: Run lint
+      uses: actions-contrib/golangci-lint@v1
+
+  spellcheck:
+    name: Spellcheck docs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: 1.14
+    - name: Run spellcheck
+      run: |
+        echo "::set-env name=GOPATH::$(go env GOPATH)"
+        echo "::add-path::$(go env GOPATH)/bin"
+        go get github.com/client9/misspell/cmd/misspell
+        misspell -error docs_src


### PR DESCRIPTION
## Description

Run each independent continuous integration jobs in parallel, instead of sequentially, one after the other.
I'm not sure about the name for the `ineffassign` check.
The workflow file should maybe be renamed : `test.yml` to something else, `ci.yml` ?

### Possible drawbacks

A bit of duplication in the workflow file ? I'm sure there's a way around that.
Maybe you'll have to check the integration with coveralls.

And since I changed the workflow file, automated requirements for PRs will be a bit thrown off. Possible workarounds : 
- re-add the old tasks, merge, then change PRs' requirements, then remove the old tasks
- or temporarily disable PRs' requirements

## Related issue(s)

None.

_(Really it's just boredom. I promise, next time I'll look at the open issues before)_
