### PR TITLE
Adding extra data to request

### DIFF
--- a/docs_src/src/guide/basics/requests.md
+++ b/docs_src/src/guide/basics/requests.md
@@ -487,6 +487,10 @@ fmt.Println(request.Lang) // "en-US"
 fmt.Println(lang.Get(request.Lang, "validation.rules.required")) // "The :field is required."
 ```
 
+#### Request.Extra
+
+`Extra` is a `map[string]interface{}` extra data to request that would allow middleware to process data that is not part of the request's body.
+
 #### Request.User
 
 <p><Badge text="Since v2.5.0"/></p>

--- a/docs_src/src/guide/basics/requests.md
+++ b/docs_src/src/guide/basics/requests.md
@@ -491,6 +491,16 @@ fmt.Println(lang.Get(request.Lang, "validation.rules.required")) // "The :field 
 
 `Extra` is a `map[string]interface{}` extra data to request that would allow middleware to process data that is not part of the request's body.
 
+**Example:**
+``` go
+func MyCustomMiddleware(next goyave.Handler) goyave.Handler {
+	return func(response *goyave.Response, request *goyave.Request) {
+        request.Extra["custom"] = "extra data" // extra data to request
+        next(response, request) // Pass to the next handler with the extra data
+    }
+}
+```
+
 #### Request.User
 
 <p><Badge text="Since v2.5.0"/></p>

--- a/request.go
+++ b/request.go
@@ -24,6 +24,7 @@ type Request struct {
 	User        interface{}
 	Rules       *validation.Rules
 	Data        map[string]interface{}
+	Extra       map[string]interface{}
 	Params      map[string]string
 	Lang        string
 }

--- a/router.go
+++ b/router.go
@@ -381,6 +381,7 @@ func (r *Router) requestHandler(match *routeMatch, w http.ResponseWriter, rawReq
 		corsOptions: r.corsOptions,
 		Rules:       match.route.validationRules,
 		Params:      match.parameters,
+		Extra:       map[string]interface{}{},
 	}
 	response := newResponse(w, rawRequest)
 	handler := match.route.handler

--- a/testsuite.go
+++ b/testsuite.go
@@ -105,6 +105,7 @@ func (s *TestSuite) CreateTestRequest(rawRequest *http.Request) *Request {
 		Rules:       nil,
 		Lang:        "en-US",
 		Params:      map[string]string{},
+		Extra:       map[string]interface{}{},
 	}
 }
 


### PR DESCRIPTION
## Description

Make a clear and detailed description of your changes, with the added benefits.

Adding an extra data to Request that would allow middleware to process data that is not part of the request's body
Example a new middleware that could wrap extra information to teh Request and later be processed.

### Possible drawbacks

`None`

## Related issue(s)

List all related issues here:

* closes #117 

## Additional information
